### PR TITLE
Add Language field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Description: Provee un acceso conveniente a mas de 17 millones de registros
 URL: https://docs.ropensci.org/censo2017/
 BugReports: https://github.com/ropensci/censo2017/issues/
 License: CC0
+Language: es
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
The package describes itself in English but then the content is mostly (fully?) in Spanish.
[The R manual](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#The-DESCRIPTION-file) requires using a field to signal that a different language than English is used. This PR adds that.

This will help people searching for packages in Spanish or avoid it those that do not know it. 
Espero que sirva de ayuda.